### PR TITLE
ThreadPatch (#59)

### DIFF
--- a/TestBCClient-Android/app/src/main/java/com/braincloud/testbcclient/MainActivity.java
+++ b/TestBCClient-Android/app/src/main/java/com/braincloud/testbcclient/MainActivity.java
@@ -26,6 +26,8 @@ import com.google.android.gms.plus.Plus;
 import org.json.JSONObject;
 
 import java.io.IOException;
+import java.util.Timer;
+import java.util.TimerTask;
 
 
 public class MainActivity extends AppCompatActivity implements View.OnClickListener,
@@ -51,12 +53,15 @@ public class MainActivity extends AppCompatActivity implements View.OnClickListe
     private String authToken;
 
     BrainCloudWrapper _wrapper;
+    Timer _timer;
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_main);
         findViewById(R.id.sign_in_button).setOnClickListener(this);
+        findViewById(R.id.btnUniversalConnect).setOnClickListener(this);
+        findViewById(R.id.btnTestTrans).setOnClickListener(this);
 
         mGoogleApiClient = new GoogleApiClient.Builder(this)
                 .addConnectionCallbacks(this)
@@ -68,10 +73,15 @@ public class MainActivity extends AppCompatActivity implements View.OnClickListe
 
         _wrapper = new BrainCloudWrapper();
         BrainCloudClient client = _wrapper.getClient();
+        client.enableLogging(true);
         String appId = "";
         String secret = "";
         String appVersion = "1.0.0";
         client.initialize(appId, secret, appVersion);
+
+        TimerTask timerTask = this.initializeTimeTask();
+        _timer = new Timer();
+        _timer.schedule(timerTask, 1000, 1000);
 
         EditText txtUser = findViewById(R.id.txtUser);
         EditText txtPwd = findViewById(R.id.txtPassword);
@@ -141,8 +151,20 @@ public class MainActivity extends AppCompatActivity implements View.OnClickListe
             case R.id.btnUniversalConnect:
                 testUniversalLogin();
                 break;
+            case R.id.btnTestTrans:
+                testTrans();
+                break;
         }
 
+    }
+
+    private TimerTask initializeTimeTask() {
+        TimerTask timerTask =  new TimerTask() {
+            public void run() {
+                _wrapper.runCallbacks();
+            }
+        };
+        return timerTask;
     }
 
     private void testGoogleLogin()
@@ -167,6 +189,11 @@ public class MainActivity extends AppCompatActivity implements View.OnClickListe
         }
     }
 
+    private void testTrans()
+    {
+        BrainCloudClient client = _wrapper.getClient();
+        client.getPlayerStateService().readUserState(this);;
+    }
     /* Track whether the sign-in button has been clicked so that we know to resolve
     * all issues preventing sign-in without waiting.
     */
@@ -231,6 +258,10 @@ public class MainActivity extends AppCompatActivity implements View.OnClickListe
             {
                 onResetEmailPassword(jsonData);
             }
+        } else if (serviceName.equals(ServiceName.playerState)) {
+            if (serviceOperation.equals(ServiceOperation.READ)) {
+                onReadPlayerState(jsonData);
+            }
         }
     }
 
@@ -257,6 +288,22 @@ public class MainActivity extends AppCompatActivity implements View.OnClickListe
 
     }
 
+    public void onReadPlayerState(JSONObject response) {
+        try {
+            int statusCode = response.getInt("status");
+            if (statusCode == 200) {
+                Log.d(TAG, "Read Player State success:" + response.toString());
+            }
+            else {
+                Log.e(TAG, "Read Player State failure:" + response.toString());
+            }
+        }
+        catch (Exception e)
+        {
+            Log.e(TAG, "Exception:", e);
+        }
+
+    }
     public void onResetEmailPassword(JSONObject response) {
         Log.i(TAG, "onResetEmailPassword() invoked: " + response);
     }

--- a/TestBCClient-Android/app/src/main/res/layout/activity_main.xml
+++ b/TestBCClient-Android/app/src/main/res/layout/activity_main.xml
@@ -7,6 +7,20 @@
     android:id="@+id/main">
 
     <Button
+        android:id="@+id/btnTestTrans"
+        style="?android:attr/buttonStyleSmall"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_alignParentEnd="true"
+        android:layout_alignParentRight="true"
+        android:layout_below="@+id/txtPassword"
+        android:layout_marginEnd="162dp"
+        android:layout_marginRight="162dp"
+        android:layout_marginTop="28dp"
+        android:onClick="onClick"
+        android:text="Test" />
+
+    <Button
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:text="@string/button_braincloud"

--- a/TestBCClient-Desktop/brainCloud/src/main/java/com/bitheads/braincloud/client/BrainCloudWrapper.java
+++ b/TestBCClient-Desktop/brainCloud/src/main/java/com/bitheads/braincloud/client/BrainCloudWrapper.java
@@ -41,8 +41,8 @@ import com.bitheads.braincloud.services.TimeService;
 import com.bitheads.braincloud.services.TournamentService;
 import com.bitheads.braincloud.services.CustomEntityService;
 import com.bitheads.braincloud.services.VirtualCurrencyService;
-import com.bitheads.braincloud.services.ItemCatalog;
-import com.bitheads.braincloud.services.UserItems;
+import com.bitheads.braincloud.services.ItemCatalogService;
+import com.bitheads.braincloud.services.UserItemsService;
 
 import java.util.prefs.Preferences;
 

--- a/brainCloud/main/java/com/bitheads/braincloud/services/UserItemsService.java
+++ b/brainCloud/main/java/com/bitheads/braincloud/services/UserItemsService.java
@@ -174,12 +174,13 @@ public class UserItemsService {
 	 * @param version
 	 * @param immediate 
 	 */
-    public void giveUserItemTo(String profileId, String itemId, int version, boolean immediate, IServerCallback callback) {
+    public void giveUserItemTo(String profileId, String itemId, int version, int quantity, boolean immediate, IServerCallback callback) {
         try {
             JSONObject data = new JSONObject();
             data.put(Parameter.profileId.name(), profileId);
             data.put(Parameter.itemId.name(), itemId);
-            data.put(Parameter.version.name(), version);
+			data.put(Parameter.version.name(), version);
+			data.put(Parameter.quantity.name(), quantity);
             data.put(Parameter.immediate.name(), immediate);
 
             ServerCall sc = new ServerCall(ServiceName.userItems, ServiceOperation.GIVE_USER_ITEM_TO, data, callback);

--- a/brainCloud/test/java/com/bitheads/braincloud/services/EventServiceTest.java
+++ b/brainCloud/test/java/com/bitheads/braincloud/services/EventServiceTest.java
@@ -54,15 +54,16 @@ public class EventServiceTest extends TestFixtureBase implements IEventCallback 
 
     @Test
     public void testUpdateIncomingEventData() throws Exception {
-        TestResult tr = new TestResult(_wrapper);
-        sendDefaultMessage();
+        //TODO
+        // TestResult tr = new TestResult(_wrapper);
+        // sendDefaultMessage();
 
-        _wrapper.getEventService().updateIncomingEventData(
-                _eventId,
-                Helpers.createJsonPair(_eventDataKey, 343),
-                tr);
+        // _wrapper.getEventService().updateIncomingEventData(
+        //         _eventId,
+        //         Helpers.createJsonPair(_eventDataKey, 343),
+        //         tr);
 
-        tr.Run();
+        // tr.Run();
     }
 
     @Test

--- a/brainCloud/test/java/com/bitheads/braincloud/services/UserItemsServiceTest.java
+++ b/brainCloud/test/java/com/bitheads/braincloud/services/UserItemsServiceTest.java
@@ -79,7 +79,7 @@ public class UserItemsServiceTest extends TestFixtureBase {
         
         TestResult tr = new TestResult(_wrapper);
         _wrapper.getUserItemsService().giveUserItemTo(
-            getUser(Users.UserB).id, "invalidForNow", 1, true,
+            getUser(Users.UserB).id, "invalidForNow", 1, 1, true,
                 tr);
         tr.RunExpectFail(400, ReasonCodes.ITEM_NOT_FOUND);
     }


### PR DESCRIPTION
* adding register and deregister RTTPresence callback

* Inconsistent wrapper and comms initialize function calls. Improper param placements cause problems with comms

* Fixing parameters in certain calls

* quick fix to chat test

* Bug fix for overly aggressive rest client thread polling.

* Re-addition of InitializeWithApps, also added overload

*  adding a note to keep initializeWithApps in the java client tests

* 4.0 Api calls, and test fix

* fixing java social leaderbaord tests.

* RTT service java

* cancelLobby

* Need to take a second look at this assert

* guard for sessions and profile id save

* Updating version for release

* Bad sig fix and tests to java

* GroupLeaderboard calls and tests

* changing groupLeaderboard Config again

* group calls and tests java

* changing createGroup to createGroupWithSummaryData for consistency across clients

* updating version for java

* itemCatalog and UserInventory services and temp tests

* Blockchain

* UserItems, PlayerState, CustomEntity

* Datastream, AsyncMatch, Identity

* updatign version

* Added logic to reduce CPU usage of comms layer

(cherry picked from commit 633bc08ae1fc12b32767ec32fb69861b5c98bfe5)

* Removed app settings

* cleanup